### PR TITLE
Make tests work (and great) again + fix deprecation warning + Travis fixes + README improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 before_install:
   - gem install bundler # need more up-to-date bundler to match Gemfile's
 rvm:
-  - 2.1.10
   - 2.2.6
   - 2.3.3
   - 2.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.2.0
-  - 2.2.1
-  - 2.2.2
-  - 2.3.0
-  - 2.3.1
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
   - 2.4.0
 notifications:
   irc: "irc.freenode.org#juwelier"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler # need more up-to-date bundler to match Gemfile's
 rvm:
   - 2.1.10
   - 2.2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ rvm:
   - 2.2.2
   - 2.3.0
   - 2.3.1
+  - 2.4.0
 notifications:
   irc: "irc.freenode.org#juwelier"

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :test do
   gem "shoulda"
   gem "mhennemeyer-output_catcher"
   gem "rr", ">= 1.0.4"
+  gem "test-unit-rr", "~> 1.0"
   gem "mocha"
   gem "redgreen"
   gem "test-construct"

--- a/README.markdown
+++ b/README.markdown
@@ -247,9 +247,9 @@ end
 
 ```ruby
 # in Rakefile
-Juwelier  require 'juwelier'
+require 'juwelier'
 require './lib/foo/version.rb'
-::Tasks.new do |gem|
+Juwelier::Tasks.new do |gem|
   # snip
   gem.version = Foo::Version::STRING
 end

--- a/README.markdown
+++ b/README.markdown
@@ -157,29 +157,19 @@ It's crucial to understand the `gem` object is just a Gem::Specification. You ca
 
 ### Project information
 
-`gem.name = "whatwhatwhat"`
+A short description about the configuration in the previous item.
 
-Every gem has a name. Among other things, the gem name is how you are able to `gem install` it. [Reference](http://guides.rubygems.org/specification-reference/#name)
+- **gem.name**: Every gem has a name. Among other things, the gem name is how you are able to `gem install` it. [Reference](http://guides.rubygems.org/specification-reference/#name)
 
-`gem.summary = %Q{TODO: one-line summary of your gem}`
+- **gem.summary**: This is a one line summary of your gem. This is displayed, for example, when you use `gem list --details` or view it on [rubygems.org](http://rubygems.org/gems/).
 
-This is a one line summary of your gem. This is displayed, for example, when you use `gem list --details` or view it on [rubygems.org](http://rubygems.org/gems/).
+- **gem.description**: Description is a longer description. Scholars ascertain that knowledge of where the description is used was lost centuries ago.
 
-`gem.description = %Q{TODO: longer description of your gem}`
+- **gem.email**: This should be a way to get a hold of you regarding the gem.
 
-Description is a longer description. Scholars ascertain that knowledge of where the description is used was lost centuries ago.
+- **gem.homepage**: The homepage should have more information about your gem. The juwelier generator guesses this based on the assumption your code lives on [GitHub](http://github.com/), using your Git configuration to find your GitHub username. This is displayed by `gem list --details` and on rubygems.org.
 
-`gem.email = "fred.mitchell@gmx.com"`
-
-This should be a way to get a hold of you regarding the gem.
-
-`gem.homepage = "http://github.com/flajann2/whatwhatwhat"`
-
-The homepage should have more information about your gem. The juwelier generator guesses this based on the assumption your code lives on [GitHub](http://github.com/), using your Git configuration to find your GitHub username. This is displayed by `gem list --details` and on rubygems.org.
-
-`gem.authors = ["Joshua Nichols"]`
-
-Hey, this is you, the author (or me in this case). The `juwelier` generator also guesses this from your Git configuration. This is displayed by `gem list --details` and on rubygems.org.
+- **gem.authors**: Hey, this is you, the author (or me in this case). The `juwelier` generator also guesses this from your Git configuration. This is displayed by `gem list --details` and on rubygems.org.
 
 ### Files
 
@@ -219,7 +209,7 @@ Executables let your gem install shell commands. Just put any executable scripts
 
 When you need more finely grained control over it, you can set it yourself:
 
-`gem.executables = ['foo'] # note, it's the file name relative to `bin/`, not the project root`
+`gem.executables = ['foo'] # note, it's the file name relative to bin/, not the project root`
 
 ### Versioning
 

--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,7 @@ the origial Jeweler up-to-date with the latest Ruby releases.
  a migration option, but in the meantime, you may wish to
  run this bash script from the root directory of your project:
 
-```
+```bash
 for f in $(grep -irl jeweler *)
 do
   sed -i 's/jeweler/juwelier/g' $f
@@ -115,7 +115,7 @@ on `origin`) and release the gem.
 
 It feels good to release code. Do it, do it often. But before that, bump the version. Then release it. There's a few ways to update the version:
 
-```
+```bash
 # version:write like before
 $ rake version:write MAJOR=0 MINOR=3 PATCH=0
 
@@ -139,7 +139,7 @@ If you've been following along so far, your gem is just a blank slate. You're go
 
 You can customize your gem by updating your `Rakefile`. With a newly generated project, it will look something like this:
 
-```
+```ruby
 require 'juwelier'
 Juwelier::Tasks.new do |gem|
   # gem is a Gem::Specification... see http://guides.rubygems.org/specification-reference/ for more options
@@ -187,7 +187,7 @@ The quickest way to add more files is to `git add` them. Juwelier uses your git 
 
 If you need to tweak the files, that's cool. Juwelier populates `gem.files` as a `Rake::FileList`. It's like a normal array, except you can `include` and `exclude` file globs:
 
-```
+```ruby
 gem.files.exclude 'tmp' # exclude temporary directory
 gem.files.include 'lib/foo/bar.rb' # explicitly include lib/foo/bar.rb
 ```
@@ -204,7 +204,7 @@ Dependencies let you define other gems that your gem needs to function. `gem ins
 
 This will ensure a version of `nokogiri` is installed, but it doesn't require anything more than that. You can provide extra args to be more specific:
 
-```
+```ruby
 gem.add_dependency 'nokogiri', '= 1.2.1' # exactly version 1.2.1
 gem.add_dependency 'nokogiri', '>= 1.2.1' # greater than or equal to 1.2.1, ie, 1.2.1, 1.2.2, 1.3.0, 2.0.0, etc
 gem.add_dependency 'nokogiri', '>= 1.2.1', '< 1.3.0' # greater than or equal to 1.2.1, but less than 1.3.0
@@ -231,7 +231,7 @@ We discussed earlier how to bump the version. The rake tasks are really just con
 
 A common pattern is to have this in a version constant in your library. This is convenient, because users of the library can query the version they are using at runtime.
 
-```
+```ruby
 # in lib/foo/version.rb
 class Foo
   module Version
@@ -245,7 +245,7 @@ class Foo
 end
 ```
 
-```
+```ruby
 # in Rakefile
 Juwelier  require 'juwelier'
 require './lib/foo/version.rb'

--- a/README.markdown
+++ b/README.markdown
@@ -28,25 +28,27 @@ the origial Jeweler up-to-date with the latest Ruby releases.
  a migration option, but in the meantime, you may wish to
  run this bash script from the root directory of your project:
 
-    for f in $(grep -irl jeweler *)
-    do
-      sed -i 's/jeweler/juwelier/g' $f
-      sed -i 's/Jeweler/Juwelier/g' $f
-    done
-    bundle update
-    
+```
+for f in $(grep -irl jeweler *)
+do
+  sed -i 's/jeweler/juwelier/g' $f
+  sed -i 's/Jeweler/Juwelier/g' $f
+done
+bundle update
+```
+
  As you know, "Juwelier" is "Jeweler" in German. Since I
  have made Germany my new home, it only seemed approporiate.
- 
+
 ## Hello, world
 
 Use RubyGems to install the heck out of juwelier to get started:
 
-    $ gem install juwelier
+`$ gem install juwelier`
 
 With juwelier installed, you can use the `juwelier` command to generate a new project. For the most basic use, just give it a name:
 
-    $ juwelier hello-gem
+`$ juwelier hello-gem`
 
 This requires some Git configuration (like name, email, GitHub account, etc), but `juwelier` will prompt along the way.
 
@@ -70,40 +72,40 @@ Check out `juwelier --help` for the most up to date options.
 
 Beyond just editing source code, you'll be interacting with your gem using `rake` a lot. To see all the tasks available with a brief description, you can run:
 
-    $ rake -T
+`$ rake -T`
 
 You'll need a version before you can start installing your gem locally. The easiest way is with the `version:write` Rake task. Let's imagine you start with 0.1.0
 
-    $ rake version:write MAJOR=0 MINOR=1 PATCH=0
+`$ rake version:write MAJOR=0 MINOR=1 PATCH=0`
 
 You can now go forth and develop, now that there's an initial version defined. Eventually, you should install and test the gem:
 
-    $ rake install
+`$ rake install`
 
 The `install` rake task builds the gem and `gem install`s it. You're all set if you're using [RVM](http://rvm.beginrescueend.com/), but you may need to run it with sudo if you have a system-installed ruby:
 
-    $ sudo rake install
+`$ sudo rake install`
 
 ### Releasing
 
 At last, it's time to [ship it](http://shipitsquirrel.github.com/)! Make sure you have everything committed and pushed, then go wild:
 
-    $ rake release
+`$ rake release`
 
 This will automatically:
 
- *Juwelier Generate `hello-gem.gemspec` and commit it
+ * Juwelier Generate `hello-gem.gemspec` and commit it
  * Use `git` to tag `v0.1.0` and push it
  * Build `hello-gem-0.1.0.gem` and push it to [rubygems.org](http://rubygems.org/gems/)
 
 `rake release` accepts REMOTE(default: `origin`), LOCAL_BRANCH(default: `master`), REMOTE_BRANCH(default: `master`) and BRANCH(default: master)as options.
 
-    $ rake release REMOTE=upstream LOCAL_BRANCH=critical-security-fix REMOTE_BRANCH=v3
+`$ rake release REMOTE=upstream LOCAL_BRANCH=critical-security-fix REMOTE_BRANCH=v3`
 
 This will tag and push the commits on your local branch named `critical-security-fix` to branch named `v3` in remote named `upstream` (if you have commit rights
 on `upstream`) and release the gem.
 
-    $ rake release BRANCH=v3
+`$ rake release BRANCH=v3`
 
 If both remote and local branches are the same, use `BRANCH` option to simplify.
 This will tag and push the commits on your local branch named `v3` to branch named `v3` in remote named `origin` (if you have commit rights
@@ -113,21 +115,23 @@ on `origin`) and release the gem.
 
 It feels good to release code. Do it, do it often. But before that, bump the version. Then release it. There's a few ways to update the version:
 
-    # version:write like before
-    $ rake version:write MAJOR=0 MINOR=3 PATCH=0
+```
+# version:write like before
+$ rake version:write MAJOR=0 MINOR=3 PATCH=0
 
-    # bump just major, ie 0.1.0 -> 1.0.0
-    $ rake version:bump:major
+# bump just major, ie 0.1.0 -> 1.0.0
+$ rake version:bump:major
 
-    # bump just minor, ie 0.1.0 -> 0.2.0
-    $ rake version:bump:minor
+# bump just minor, ie 0.1.0 -> 0.2.0
+$ rake version:bump:minor
 
-    # bump just patch, ie 0.1.0 -> 0.1.1
-    $ rake version:bump:patch
+# bump just patch, ie 0.1.0 -> 0.1.1
+$ rake version:bump:patch
+```
 
 Then it's the same `release` we used before:
 
-    $ rake release
+`$ rake release`
 
 ## Customizing your gem
 
@@ -135,119 +139,129 @@ If you've been following along so far, your gem is just a blank slate. You're go
 
 You can customize your gem by updating your `Rakefile`. With a newly generated project, it will look something like this:
 
- Juwelier   require 'juwelier'
-    ::Tasks.new do |gem|
-      # gem is a Gem::Specification... see http://guides.rubygems.org/specification-reference/ for more options
-      gem.name = "whatwhatwhat"
-      gem.summary = %Q{TODO: one-line summary of your gem}
-      gem.description = %Q{TODO: longer description of your gem}
-      gem.email = "fred.mitchell@gmx.com"
-      gem.homepage = "http://github.com/flajann2/whatwhatwhat"
-  Juwelier    gem.authors = ["Joshua Nichols"]
-    end
-  JuwelierJuwelier  ::RubygemsDotOrgTasks.new
+```
+require 'juwelier'
+Juwelier::Tasks.new do |gem|
+  # gem is a Gem::Specification... see http://guides.rubygems.org/specification-reference/ for more options
+  gem.name = "whatwhatwhat"
+  gem.summary = %Q{TODO: one-line summary of your gem}
+  gem.description = %Q{TODO: longer description of your gem}
+  gem.email = "fred.mitchell@gmx.com"
+  gem.homepage = "http://github.com/flajann2/whatwhatwhat"
+  gem.authors = ["Joshua Nichols"]
+end
+JuwelierJuwelier::RubygemsDotOrgTasks.new
+```
 
 It's crucial to understand the `gem` object is just a Gem::Specification. You can read up about it at [guides.rubygems.org/specification-reference](http://guides.rubygems.org/specification-reference/). This is the most basic way of specifying a gem, -managed or not.  just exposes this to you, in addition to providing some reasonable defaults, which we'll explore now.
 
 ### Project information
 
-    gem.name = "whatwhatwhat"
+`gem.name = "whatwhatwhat"`
 
 Every gem has a name. Among other things, the gem name is how you are able to `gem install` it. [Reference](http://guides.rubygems.org/specification-reference/#name)
 
-    gem.summary = %Q{TODO: one-line summary of your gem}
+`gem.summary = %Q{TODO: one-line summary of your gem}`
 
 This is a one line summary of your gem. This is displayed, for example, when you use `gem list --details` or view it on [rubygems.org](http://rubygems.org/gems/).
 
-    gem.description = %Q{TODO: longer description of your gem}
+`gem.description = %Q{TODO: longer description of your gem}`
 
 Description is a longer description. Scholars ascertain that knowledge of where the description is used was lost centuries ago.
 
-    gem.email = "fred.mitchell@gmx.com"
+`gem.email = "fred.mitchell@gmx.com"`
 
 This should be a way to get a hold of you regarding the gem.
 
-    gem.homepage = "http://github.com/flajann2/whatwhatwhat"
+`gem.homepage = "http://github.com/flajann2/whatwhatwhat"`
 
 The homepage should have more information about your gem. The juwelier generator guesses this based on the assumption your code lives on [GitHub](http://github.com/), using your Git configuration to find your GitHub username. This is displayed by `gem list --details` and on rubygems.org.
 
-    gem.authors = ["Joshua Nichols"]
+`gem.authors = ["Joshua Nichols"]`
 
 Hey, this is you, the author (or me in this case). The `juwelier` generator also guesses this from your Git configuration. This is displayed by `gem list --details` and on rubygems.org.
 
-##Juwelier# Files
+### Files
 
-ThJuweliere quickest way to add more files is to `git add` them.  uses your Git repository to populate your gem's files by including added and committed and excluding `.gitignore`d. In most cases, this is reasonable enough.
+The quickest way to add more files is to `git add` them. Juwelier uses your git repository to populate your gem's files by including added and committed and excluding `.gitignore`d. In most cases, this is reasonable enough.
 
-If you need to tweak the files, that's cool.  populates `gem.files` as a `Rake::FileList`. It's like a normal array, except you can `include` and `exclude` file globs:
+If you need to tweak the files, that's cool. Juwelier populates `gem.files` as a `Rake::FileList`. It's like a normal array, except you can `include` and `exclude` file globs:
 
-    gem.files.exclude 'tmp' # exclude temporary directory
-    gem.files.include 'lib/foo/bar.rb' # explicitly include lib/foo/bar.rb
+```
+gem.files.exclude 'tmp' # exclude temporary directory
+gem.files.include 'lib/foo/bar.rb' # explicitly include lib/foo/bar.rb
+```
 
 If that's not enough, you can just set `gem.files` outright
 
-    gem.files = Dir.glob('lib/**/*.rb')
+`gem.files = Dir.glob('lib/**/*.rb')`
 
 ### Dependencies
 
 Dependencies let you define other gems that your gem needs to function. `gem install your-gem` will install your-gem's dependencies along with it, and when you use your-gem in an application, the dependencies will be made available. Use `gem.add_dependency` to register them. [Reference](http://guides.rubygems.org/specification-reference/#add_development_dependency)
 
-    gem.add_dependency 'nokogiri'
+`gem.add_dependency 'nokogiri'`
 
 This will ensure a version of `nokogiri` is installed, but it doesn't require anything more than that. You can provide extra args to be more specific:
 
-    gem.add_dependency 'nokogiri', '= 1.2.1' # exactly version 1.2.1
-    gem.add_dependency 'nokogiri', '>= 1.2.1' # greater than or equal to 1.2.1, ie, 1.2.1, 1.2.2, 1.3.0, 2.0.0, etc
-    gem.add_dependency 'nokogiri', '>= 1.2.1', '< 1.3.0' # greater than or equal to 1.2.1, but less than 1.3.0
-    gem.add_dependency 'nokogiri', '~> 1.2.1' # same thing, but more concise
+```
+gem.add_dependency 'nokogiri', '= 1.2.1' # exactly version 1.2.1
+gem.add_dependency 'nokogiri', '>= 1.2.1' # greater than or equal to 1.2.1, ie, 1.2.1, 1.2.2, 1.3.0, 2.0.0, etc
+gem.add_dependency 'nokogiri', '>= 1.2.1', '< 1.3.0' # greater than or equal to 1.2.1, but less than 1.3.0
+gem.add_dependency 'nokogiri', '~> 1.2.1' # same thing, but more concise
+```
 
 When specifying which version is required, there's a bit of the condunrum. You want to allow the most versions possible, but you want to be sure they are compatible. Using `>= 1.2.1` is fine most of the time, except until the point that 2.0.0 comes out and totally breaks backwards the API. That's when it's good to use `~> 1.2.1`, which requires any version in the `1.2` family, starting with `1.2.1`.
 
-##Juwelier# Executables
+### Executables
 
 Executables let your gem install shell commands. Just put any executable scripts in the `bin/` directory, make sure they are added using `git`, and  will take care of the rest.
 
 When you need more finely grained control over it, you can set it yourself:
 
-    gem.executables = ['foo'] # note, it's the file name relative to `bin/`, not the project root
+`gem.executables = ['foo'] # note, it's the file name relative to `bin/`, not the project root`
 
 ### Versioning
 
-WeJuwelierJuwelier discussed earlier how to bump the version. The rake tasks are really just convience methods for manipulating the `VERSION` file. It just contains a version string, like `1.2.3`.
+We discussed earlier how to bump the version. The rake tasks are really just convience methods for manipulating the `VERSION` file. It just contains a version string, like `1.2.3`.
 
 `VERSION` is a convention used by , and is used to populate `gem.version`. You can actually set this yourself, and  won't try to override it:
 
-    gem.version = '1.2.3'
+`gem.version = '1.2.3'`
 
 A common pattern is to have this in a version constant in your library. This is convenient, because users of the library can query the version they are using at runtime.
 
-    # in lib/foo/version.rb
-    class Foo
-      module Version
-        MAJOR = 1
-        MINOR = 2
-        PATCH = 3
-        BUILD = 'pre3'
+```
+# in lib/foo/version.rb
+class Foo
+  module Version
+    MAJOR = 1
+    MINOR = 2
+    PATCH = 3
+    BUILD = 'pre3'
 
-        STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')
-      end
-    end
+    STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')
+  end
+end
+```
 
-    # in Rakefile
-  Juwelier  require 'juwelier'
-    require './lib/foo/version.rb'
-    ::Tasks.new do |gem|
-      # snip
-      gem.version = Foo::Version::STRING
-    end
+```
+# in Rakefile
+Juwelier  require 'juwelier'
+require './lib/foo/version.rb'
+::Tasks.new do |gem|
+  # snip
+  gem.version = Foo::Version::STRING
+end
+```
 
-##Juwelier# Rake tasks
+### Rake tasks
 
- lives inside of Rake. As a result, they are dear friends. But, that friendship doesn't interfere with typical Rake operations.
+Juwelier tasks lives inside of Rake. As a result, they are dear friends. But, that friendship doesn't interfere with typical Rake operations.
 
- The Juwelier Rake means you can define your own namespaces, tasks, or use third party Rake libraries without cause for concern.
+This means you can define your own namespaces, tasks, or use third party Rake libraries without cause for concern.
 
-## Contributing to 
+## Contributing to
 
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet
 * Ask on the [mailing list](http://groups.google.com/group/juwelier-rb) for feedback on your proposal, to see if somebody else has done it.

--- a/features/step_definitions/filesystem_steps.rb
+++ b/features/step_definitions/filesystem_steps.rb
@@ -21,7 +21,7 @@ Given /^I use the juwelier command to generate the "([^"]+)" project in the work
 end
 
 Given /^"([^"]+)" does not exist$/ do |file|
-  assert ! File.exists?(File.join(@working_dir, file))
+  assert ! File.exist?(File.join(@working_dir, file))
 end
 
 When /^I run "([^"]+)" in "([^"]+)"$/ do |command, directory|

--- a/features/step_definitions/generator_steps.rb
+++ b/features/step_definitions/generator_steps.rb
@@ -110,7 +110,7 @@ end
 Then /^a directory named '(.*)' is created$/ do |directory|
   directory = File.join(@working_dir, directory)
 
-  assert File.exists?(directory), "#{directory} did not exist"
+  assert File.exist?(directory), "#{directory} did not exist"
   assert File.directory?(directory), "#{directory} is not a directory"
 end
 
@@ -124,14 +124,14 @@ end
 Then /^a file named '(.*)' is created$/ do |file|
   file = File.join(@working_dir, file)
 
-  assert File.exists?(file), "#{file} expected to exist, but did not"
+  assert File.exist?(file), "#{file} expected to exist, but did not"
   assert File.file?(file), "#{file} expected to be a file, but is not"
 end
 
 Then /^a file named '(.*)' is not created$/ do |file|
   file = File.join(@working_dir, file)
 
-  assert ! File.exists?(file), "#{file} expected to not exist, but did"
+  assert ! File.exist?(file), "#{file} expected to not exist, but did"
 end
 
 Then /^a sane '.gitignore' is created$/ do

--- a/lib/juwelier.rb
+++ b/lib/juwelier.rb
@@ -159,7 +159,7 @@ class Juwelier
       base_dir = File.expand_path(self.base_dir || ".")
     end
     return nil if base_dir==File.dirname("/")
-    return base_dir if File.exists?(File.join(base_dir, '.git'))
+    return base_dir if File.exist?(File.join(base_dir, '.git'))
     return git_base_dir(base_dir)
   end    
 
@@ -168,7 +168,7 @@ class Juwelier
   end
 
   def version_file_exists?
-    File.exists?(@version_helper.plaintext_path) || File.exists?(@version_helper.yaml_path)
+    File.exist?(@version_helper.plaintext_path) || File.exist?(@version_helper.yaml_path)
   end
 
   def expects_version_file?

--- a/lib/juwelier/generator.rb
+++ b/lib/juwelier/generator.rb
@@ -201,7 +201,7 @@ class Juwelier
   private
 
     def create_files
-      unless File.exists?(target_dir) || File.directory?(target_dir)
+      unless File.exist?(target_dir) || File.directory?(target_dir)
         FileUtils.mkdir target_dir
       else
         raise FileInTheWay, "The directory #{target_dir} already exists, aborting. Maybe move it out of the way before continuing?"

--- a/lib/juwelier/version_helper.rb
+++ b/lib/juwelier/version_helper.rb
@@ -39,7 +39,7 @@ class Juwelier
       end
 
       def read_yaml
-        if File.exists?(yaml_path)
+        if File.exist?(yaml_path)
           YAML.load_file(yaml_path)
         else
           raise VersionYmlError, "#{yaml_path} does not exist!"
@@ -86,12 +86,12 @@ class Juwelier
     def initialize(base_dir)
       self.base_dir = base_dir
 
-      if File.exists?(yaml_path)
+      if File.exist?(yaml_path)
         extend YamlExtension
         parse_yaml
       else
         extend PlaintextExtension
-        if File.exists?(plaintext_path)
+        if File.exist?(plaintext_path)
           parse_plaintext
         end
       end

--- a/test/juwelier/commands/test_release_to_git.rb
+++ b/test/juwelier/commands/test_release_to_git.rb
@@ -264,7 +264,7 @@ class Juwelier
           deleted { options[:deleted] }
           changed { options[:changed] }
         end
-        
+
       end
     end
   end

--- a/test/juwelier/commands/test_release_to_git.rb
+++ b/test/juwelier/commands/test_release_to_git.rb
@@ -102,7 +102,7 @@ class Juwelier
           end
 
           should 'raise error' do
-            assert_raises RuntimeError, /try commiting/i do
+            assert_raises RuntimeError do
               @command.run
             end
           end

--- a/test/juwelier/commands/test_release_to_github.rb
+++ b/test/juwelier/commands/test_release_to_github.rb
@@ -470,7 +470,7 @@ class Juwelier
           deleted { options[:deleted] }
           changed { options[:changed] }
         end
-        
+
       end
     end
   end

--- a/test/juwelier/commands/test_release_to_github.rb
+++ b/test/juwelier/commands/test_release_to_github.rb
@@ -120,7 +120,7 @@ class Juwelier
           end
 
           should 'raise error' do
-            assert_raises RuntimeError, /try commiting/i do
+            assert_raises RuntimeError do
               @command.run
             end
           end

--- a/test/juwelier/test_gemspec_helper.rb
+++ b/test/juwelier/test_gemspec_helper.rb
@@ -30,7 +30,7 @@ class TestGemspecHelper < Test::Unit::TestCase
     end
 
     should "create gemspec file" do
-      assert File.exists?(@helper.path)
+      assert File.exist?(@helper.path)
     end
 
     should "make valid spec" do

--- a/test/juwelier/test_version_helper.rb
+++ b/test/juwelier/test_version_helper.rb
@@ -165,10 +165,10 @@ class TestVersionHelper < Test::Unit::TestCase
 
       should_have_version 0, 0, 1
       should "not create VERSION.yml" do
-        assert ! File.exists?(File.join(VERSION_TMP_DIR, 'VERSION.yml'))
+        assert ! File.exist?(File.join(VERSION_TMP_DIR, 'VERSION.yml'))
       end
       should "not create VERSION" do
-        assert ! File.exists?(File.join(VERSION_TMP_DIR, 'VERSION'))
+        assert ! File.exist?(File.join(VERSION_TMP_DIR, 'VERSION'))
       end
 
       context "outputting" do
@@ -177,7 +177,7 @@ class TestVersionHelper < Test::Unit::TestCase
         end
 
         should "create VERSION" do
-          assert File.exists?(File.join(VERSION_TMP_DIR, 'VERSION'))
+          assert File.exist?(File.join(VERSION_TMP_DIR, 'VERSION'))
         end
 
         context "re-reading VERSION" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,6 @@
 require 'test/unit'
+require 'rr'
+require 'test/unit/rr'
 require 'rubygems'
 
 require 'bundler'
@@ -15,7 +17,6 @@ end
 
 require 'rake'
 require 'shoulda'
-require 'rr'
 #require 'redgreen'
 require 'construct'
 require 'git'
@@ -38,7 +39,6 @@ class RubyForgeStub
 end
 
 class Test::Unit::TestCase
-  include RR::Adapters::TestUnit unless include?(RR::Adapters::TestUnit)
   include Construct::Helpers
 
   def tmp_dir


### PR DESCRIPTION
- [x] There's no need to tinker with test case class anymore, `test-unit-rr` does this for us. 
- [x] Fixed 2 specs which had the wrong usage of `assert_raises`
- [x] Renamed all uses of `File.exists?` to `File.exist?` to silence deprecation warning
- [x] Fixed Travis build: trimmed supported ruby versions, fixed bundler version in older rubies
- [x] README improvements

This should be enough to make `juwelier` have a working Travis build and thus give security for any contributor to add features. 
