### PR TITLE
Reset $SAFE to 0 for ruby 2.6

### DIFF
--- a/lib/juwelier/gemspec_helper.rb
+++ b/lib/juwelier/gemspec_helper.rb
@@ -49,6 +49,8 @@ class Juwelier
       data = self.to_ruby
       parsed_gemspec = nil
       Thread.new { parsed_gemspec = eval("$SAFE = 1\n#{data}", binding, path) }.join
+      # Need to reset $SAFE to 0 as it is process global since ruby 2.6
+      $SAFE = 0 if $SAFE == 1
       parsed_gemspec
     end
 


### PR DESCRIPTION
Before ruby 2.6, $SAFE was global to a thread, so setting it in a
separate thread would not affect main thread.

Since ruby 2.6, $SAFE is global to the process:
https://bugs.ruby-lang.org/issues/14250. This leads to unexpected
SecurityError occuring with ruby 2.6. The recommended approach is to
restore $SAFE to 0.

This should fix #7

It is the same PR as https://github.com/technicalpickles/jeweler/pull/305, another dev switched from jeweler to juwelier and it went unoticed until we needed to make a release. So I make the same PR again.