### PR TITLE
Update generated gem bundler dependency to >= 1.0

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,7 +17,7 @@ require 'active_support'
 require 'test/unit/assertions'
 World(Test::Unit::Assertions)
 
-require 'test_construct'
+require 'construct'
 World(Construct::Helpers)
 
 def yank_task_info(content, task)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,7 +17,7 @@ require 'active_support'
 require 'test/unit/assertions'
 World(Test::Unit::Assertions)
 
-require 'construct'
+require 'test_construct'
 World(Construct::Helpers)
 
 def yank_task_info(content, task)

--- a/lib/juwelier/generator.rb
+++ b/lib/juwelier/generator.rb
@@ -154,7 +154,7 @@ class Juwelier
     end
 
     def constant_name
-      self.project_name.camel
+      self.project_name.underscore.camel
     end
 
     def extension_name

--- a/lib/juwelier/generator.rb
+++ b/lib/juwelier/generator.rb
@@ -113,7 +113,7 @@ class Juwelier
 
       development_dependencies << ["cucumber", ">= 0"] if should_use_cucumber
 
-      development_dependencies << ["bundler", "~> 1.0"]
+      development_dependencies << ["bundler", ">= 1.0"]
       development_dependencies << ["juwelier", "~> #{Juwelier::Version::STRING}"]
       development_dependencies << ["simplecov", ">= 0"]
       
@@ -154,7 +154,7 @@ class Juwelier
     end
 
     def constant_name
-      self.project_name.underscore.camel
+      self.project_name.snake.camel
     end
 
     def extension_name
@@ -208,7 +208,10 @@ class Juwelier
 
       output_template_in_target '.gitignore'
       output_template_in_target 'Rakefile'
-      output_template_in_target 'Gemfile' if should_use_bundler
+      if should_use_bundler
+        output_template_in_target 'Gemfile'
+        system 'bundle install'
+      end
       output_template_in_target 'LICENSE.txt'
       output_template_in_target "README.#{use_readme_format}"
       output_template_in_target '.document'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,7 @@ end
 require 'rake'
 require 'shoulda'
 #require 'redgreen'
-require 'construct'
+require 'test_construct'
 require 'git'
 require 'time'
 
@@ -39,7 +39,7 @@ class RubyForgeStub
 end
 
 class Test::Unit::TestCase
-  include Construct::Helpers
+  include TestConstruct::Helpers
 
   def tmp_dir
     TMP_DIR


### PR DESCRIPTION
Hi,

I noticed that generated gem Bundler dependency is pinned to 1.0 (an old version), so I relaxed to ">= 1.0"

Also, fixed a broken test and a dependency on test_construction.

Cheers.

p.s. if you need maintainers, I’d be happy to help maintain Juwelier and Jeweler since I’ve been relying on since the mid 2000s and autoinstall for users of [Glimmer DSL for SWT](https://github.com/AndyObtiva/glimmer-dsl-swt) during scaffolding. 