### PR TITLE
Ignore Gemfile.lock for default setup

### DIFF
--- a/features/step_definitions/generator_steps.rb
+++ b/features/step_definitions/generator_steps.rb
@@ -142,6 +142,7 @@ Then /^a sane '.gitignore' is created$/ do
   step "'.DS_Store' is ignored by git"
   step "'rdoc' is ignored by git"
   step "'pkg' is ignored by git"
+  step "'Gemfile.lock' is ignored by git"
 end
 
 Then /^'(.*)' is ignored by git$/ do |git_ignore|
@@ -356,7 +357,7 @@ end
 Then /^'Gemfile' has a development dependency on the current version of juwelier$/ do
   @gemfile_content ||= File.read(File.join(@working_dir, @name, 'Gemfile'))
   group_block = yank_group_info(@gemfile_content, 'development')
-  
+
   assert_match %Q{gem "juwelier", "~> #{Juwelier::Version::STRING}"}, group_block
 end
 

--- a/lib/juwelier/generator.rb
+++ b/lib/juwelier/generator.rb
@@ -24,12 +24,12 @@ class Juwelier
   class NoGitHubUser < StandardError
   end
   class GitInitFailed < StandardError
-  end    
+  end
   class GitRepoCreationFailed < StandardError
   end
 
   # Generator for creating a juwelier-enabled project
-  class Generator    
+  class Generator
     require 'juwelier/generator/options'
     require 'juwelier/generator/application'
 
@@ -50,7 +50,7 @@ class Juwelier
 
     attr_accessor :target_dir, :user_name, :user_email, :summary, :homepage,
                   :description, :project_name, :github_username,
-                  :repo, :should_create_remote_repo, 
+                  :repo, :should_create_remote_repo,
                   :testing_framework, :documentation_framework,
                   :should_use_cucumber, :should_use_bundler, :should_use_semver,
                   :should_setup_rubyforge, :should_use_reek, :should_use_roodi,
@@ -116,10 +116,10 @@ class Juwelier
       development_dependencies << ["bundler", "~> 1.0"]
       development_dependencies << ["juwelier", "~> #{Juwelier::Version::STRING}"]
       development_dependencies << ["simplecov", ">= 0"]
-      
+
       development_dependencies << ["reek", "~> 1.2.8"] if should_use_reek
       development_dependencies << ["roodi", "~> 2.1.0"] if should_use_roodi
-      
+
       development_dependencies <<
         ["pry",                "~> 0"] <<
         ["pry-byebug",         "~> 3"] <<
@@ -127,14 +127,14 @@ class Juwelier
         ["pry-remote",         "~> 0"] <<
         ["pry-rescue",         "~> 1"] <<
         ["pry-stack_explorer", "~> 0"] if should_use_pry
-                                         
+
       production_dependencies << ["semver2", "~> 3"] if should_use_semver
       production_dependencies << ['ffi', '~> 1'] if should_be_rusty
-      
+
       self.user_name       = options[:user_name]
       self.user_email      = options[:user_email]
       self.homepage        = options[:homepage]
-      
+
       self.git_remote      = options[:git_remote]
 
       raise NoGitUserName unless self.user_name
@@ -160,7 +160,7 @@ class Juwelier
     def extension_name
       "lib#{self.project_name.snake}.so"
     end
-    
+
     def lib_filename ; "#{project_name}.rb" ; end
     def bin_filename ; "#{should_create_bin}" ; end
 
@@ -173,7 +173,7 @@ class Juwelier
     end
 
     def lib_dir      ; 'lib'      ; end
-    def bin_dir      ; 'bin'      ; end    
+    def bin_dir      ; 'bin'      ; end
     def rust_dir     ; 'rust'     ; end
     def rust_src_dir ; rust_dir + '/src' ; end
 
@@ -224,7 +224,7 @@ class Juwelier
       if should_use_semver
         output_template_in_target '.semver'
       end
-      
+
       if should_create_bin
         mkdir_in_target           bin_dir
         touch_in_target           File.join(bin_dir, bin_filename)
@@ -244,7 +244,7 @@ class Juwelier
         mkdir_in_target rust_src_dir
         output_template_in_target File.join(rust_src_dir, 'lib.rs')
       end
-      
+
       if testing_framework == :rspec
         output_template_in_target File.join(testing_framework.to_s, '.rspec'),
                                   '.rspec'
@@ -326,7 +326,7 @@ class Juwelier
         end
       end
     end
-    
+
     def create_and_push_repo
       puts "Please provide your Github password to create the Github repository"
       begin

--- a/lib/juwelier/templates/.gitignore
+++ b/lib/juwelier/templates/.gitignore
@@ -14,8 +14,9 @@ doc
 
 # juwelier generated
 pkg
+Gemfile.lock
 
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
+# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore:
 #
 # * Create a file at ~/.gitignore
 # * Include files you want ignored


### PR DESCRIPTION
I recently saw gems which have been created with _juwelier_, which contained `Gemfile.lock` in their sources. Since we should not check `Gemfile.lock` into version control (see [Katz](https://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/)), we should also create default `.gitignore` templates reflecting that.

(I can also propose this PR also without the whitespace changes, if you want)