### PR TITLE
Shorten markdown to md and fix markdown issue

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,7 +17,7 @@ require 'active_support'
 require 'test/unit/assertions'
 World(Test::Unit::Assertions)
 
-require 'test_construct'
+require 'construct'
 World(Construct::Helpers)
 
 def yank_task_info(content, task)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,7 +17,7 @@ require 'active_support'
 require 'test/unit/assertions'
 World(Test::Unit::Assertions)
 
-require 'construct'
+require 'test_construct'
 World(Construct::Helpers)
 
 def yank_task_info(content, task)

--- a/lib/juwelier/generator.rb
+++ b/lib/juwelier/generator.rb
@@ -154,7 +154,7 @@ class Juwelier
     end
 
     def constant_name
-      self.project_name.camel
+      self.project_name.underscore.camel
     end
 
     def extension_name

--- a/lib/juwelier/generator.rb
+++ b/lib/juwelier/generator.rb
@@ -113,7 +113,7 @@ class Juwelier
 
       development_dependencies << ["cucumber", ">= 0"] if should_use_cucumber
 
-      development_dependencies << ["bundler", "~> 1.0"]
+      development_dependencies << ["bundler", ">= 1.0"]
       development_dependencies << ["juwelier", "~> #{Juwelier::Version::STRING}"]
       development_dependencies << ["simplecov", ">= 0"]
       
@@ -154,7 +154,7 @@ class Juwelier
     end
 
     def constant_name
-      self.project_name.underscore.camel
+      self.project_name.snake.camel
     end
 
     def extension_name
@@ -208,7 +208,10 @@ class Juwelier
 
       output_template_in_target '.gitignore'
       output_template_in_target 'Rakefile'
-      output_template_in_target 'Gemfile' if should_use_bundler
+      if should_use_bundler
+        output_template_in_target 'Gemfile'
+        system 'bundle install'
+      end
       output_template_in_target 'LICENSE.txt'
       output_template_in_target "README.#{use_readme_format}"
       output_template_in_target '.document'

--- a/lib/juwelier/generator/options.rb
+++ b/lib/juwelier/generator/options.rb
@@ -154,7 +154,7 @@ class Juwelier
           end
           
           o.on('--markdown', 'use Markdown for the readme') do
-            self[:readme_format] = :markdown
+            self[:readme_format] = :md
           end
 
           o.on('-v', '--version', 'show version') do

--- a/lib/juwelier/templates/README.md
+++ b/lib/juwelier/templates/README.md
@@ -1,10 +1,8 @@
-<%= project_name %>
-===================
+# <%= project_name %>
 
 Description goes here.
 
-Contributing to <%= project_name %>
-------------------------------------------
+## Contributing to <%= project_name %>
 
 -   Check out the latest master to make sure the feature hasn't been
     implemented or the bug hasn't been fixed yet.
@@ -20,8 +18,7 @@ Contributing to <%= project_name %>
     is fine, but please isolate to its own commit so I can cherry-pick
     around it.
 
-Copyright
----------
+## Copyright
 
 Copyright (c) <%= Time.now.year %> <%= user_name %>. See
 LICENSE.txt for further details.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,7 @@ end
 require 'rake'
 require 'shoulda'
 #require 'redgreen'
-require 'construct'
+require 'test_construct'
 require 'git'
 require 'time'
 
@@ -39,7 +39,7 @@ class RubyForgeStub
 end
 
 class Test::Unit::TestCase
-  include Construct::Helpers
+  include TestConstruct::Helpers
 
   def tmp_dir
     TMP_DIR


### PR DESCRIPTION
- Shorten README extension for markdown to "md" since that’s the desired and common extension on most Ruby projects I encounter like Rails
- Fix Known Issue: On generation of the Markdown, the initial title does not linefeed before the header sequence.

(note: depends on https://github.com/flajann2/juwelier/pull/11 to pass the tests since it fixes the test suite, which was broken prior to my changes)

p.s. if you need maintainers, I’d be happy to help maintain Juwelier and Jeweler since I’ve been relying on since the mid 2000s and autoinstall for users of [Glimmer DSL for SWT](https://github.com/AndyObtiva/glimmer-dsl-swt) during scaffolding. 