### PR TITLE
RVM support & rspec --init support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,11 @@ test/jeweler/version_tmp
 test/version_tmp
 tmp
 
-# rbenv settings
-.ruby-version
+# rvm/rbenv settings
+/.ruby-version
+/.ruby-gemset
 
 Gemfile.lock
+
+# Gladiator (Glimmer Editor)
+.gladiator

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ Juwelier::Tasks.new do |gem|
   gem.license = "MIT"
   gem.authors = ["Fred Mitchell", "Josh Nichols", "Yusuke Murata"]
   gem.email = ["fred.mitchell@gmx.de", "fred.mitchell@gmx.com", "info@muratayusuke.com"]
-  gem.files.include %w(lib/juwelier/templates/.document lib/juwelier/templates/.gitignore)
+  gem.files.include %w(lib/juwelier/templates/.document lib/juwelier/templates/.gitignore lib/juwelier/templates/.ruby-version lib/juwelier/templates/.ruby-gemset)
 
   # dependencies defined in Gemfile
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,7 +17,7 @@ require 'active_support'
 require 'test/unit/assertions'
 World(Test::Unit::Assertions)
 
-require 'test_construct'
+require 'construct'
 World(Construct::Helpers)
 
 def yank_task_info(content, task)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,7 +17,7 @@ require 'active_support'
 require 'test/unit/assertions'
 World(Test::Unit::Assertions)
 
-require 'construct'
+require 'test_construct'
 World(Construct::Helpers)
 
 def yank_task_info(content, task)

--- a/juwelier.gemspec
+++ b/juwelier.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Fred Mitchell".freeze, "Josh Nichols".freeze, "Yusuke Murata".freeze]
-  s.date = "2018-01-18"
+  s.date = "2021-01-05"
   s.description = "Simple and opinionated helper for creating Rubygem projects on GitHub".freeze
   s.email = ["fred.mitchell@gmx.de".freeze, "fred.mitchell@gmx.com".freeze, "info@muratayusuke.com".freeze]
   s.executables = ["juwelier".freeze]
@@ -94,6 +94,8 @@ Gem::Specification.new do |s|
     "lib/juwelier/tasks.rb",
     "lib/juwelier/templates/.document",
     "lib/juwelier/templates/.gitignore",
+    "lib/juwelier/templates/.ruby-gemset",
+    "lib/juwelier/templates/.ruby-version",
     "lib/juwelier/templates/.semver",
     "lib/juwelier/templates/Gemfile",
     "lib/juwelier/templates/LICENSE.txt",
@@ -200,45 +202,29 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/flajann2/juwelier".freeze
   s.licenses = ["MIT".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 2.2.2".freeze)
-  s.rubygems_version = "2.7.3".freeze
+  s.rubygems_version = "3.1.4".freeze
   s.summary = "Powerful and Opinionated tool for creating and managing RubyGem projects".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
+  end
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rake>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<git>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<nokogiri>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<github_api>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<highline>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<bundler>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<rdoc>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<builder>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<semver2>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<psych>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<kamelcase>.freeze, ["~> 0"])
-      s.add_development_dependency(%q<yard>.freeze, [">= 0"])
-      s.add_development_dependency(%q<bluecloth>.freeze, [">= 0"])
-      s.add_development_dependency(%q<cucumber>.freeze, [">= 0"])
-      s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
-    else
-      s.add_dependency(%q<rake>.freeze, [">= 0"])
-      s.add_dependency(%q<git>.freeze, [">= 0"])
-      s.add_dependency(%q<nokogiri>.freeze, [">= 0"])
-      s.add_dependency(%q<github_api>.freeze, [">= 0"])
-      s.add_dependency(%q<highline>.freeze, [">= 0"])
-      s.add_dependency(%q<bundler>.freeze, [">= 0"])
-      s.add_dependency(%q<rdoc>.freeze, [">= 0"])
-      s.add_dependency(%q<builder>.freeze, [">= 0"])
-      s.add_dependency(%q<semver2>.freeze, [">= 0"])
-      s.add_dependency(%q<psych>.freeze, [">= 0"])
-      s.add_dependency(%q<kamelcase>.freeze, ["~> 0"])
-      s.add_dependency(%q<yard>.freeze, [">= 0"])
-      s.add_dependency(%q<bluecloth>.freeze, [">= 0"])
-      s.add_dependency(%q<cucumber>.freeze, [">= 0"])
-      s.add_dependency(%q<simplecov>.freeze, [">= 0"])
-    end
+  if s.respond_to? :add_runtime_dependency then
+    s.add_runtime_dependency(%q<rake>.freeze, [">= 0"])
+    s.add_runtime_dependency(%q<git>.freeze, [">= 0"])
+    s.add_runtime_dependency(%q<nokogiri>.freeze, [">= 0"])
+    s.add_runtime_dependency(%q<github_api>.freeze, [">= 0"])
+    s.add_runtime_dependency(%q<highline>.freeze, [">= 0"])
+    s.add_runtime_dependency(%q<bundler>.freeze, [">= 0"])
+    s.add_runtime_dependency(%q<rdoc>.freeze, [">= 0"])
+    s.add_runtime_dependency(%q<builder>.freeze, [">= 0"])
+    s.add_runtime_dependency(%q<semver2>.freeze, [">= 0"])
+    s.add_runtime_dependency(%q<psych>.freeze, [">= 0"])
+    s.add_runtime_dependency(%q<kamelcase>.freeze, ["~> 0"])
+    s.add_development_dependency(%q<yard>.freeze, [">= 0"])
+    s.add_development_dependency(%q<bluecloth>.freeze, [">= 0"])
+    s.add_development_dependency(%q<cucumber>.freeze, [">= 0"])
+    s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
   else
     s.add_dependency(%q<rake>.freeze, [">= 0"])
     s.add_dependency(%q<git>.freeze, [">= 0"])

--- a/lib/juwelier/generator.rb
+++ b/lib/juwelier/generator.rb
@@ -154,7 +154,7 @@ class Juwelier
     end
 
     def constant_name
-      self.project_name.camel
+      self.project_name.underscore.camel
     end
 
     def extension_name

--- a/lib/juwelier/generator.rb
+++ b/lib/juwelier/generator.rb
@@ -24,12 +24,12 @@ class Juwelier
   class NoGitHubUser < StandardError
   end
   class GitInitFailed < StandardError
-  end    
+  end
   class GitRepoCreationFailed < StandardError
   end
 
   # Generator for creating a juwelier-enabled project
-  class Generator    
+  class Generator
     require 'juwelier/generator/options'
     require 'juwelier/generator/application'
 
@@ -50,14 +50,15 @@ class Juwelier
 
     attr_accessor :target_dir, :user_name, :user_email, :summary, :homepage,
                   :description, :project_name, :github_username,
-                  :repo, :should_create_remote_repo, 
+                  :repo, :should_create_remote_repo,
                   :testing_framework, :documentation_framework,
                   :should_use_cucumber, :should_use_bundler, :should_use_semver,
                   :should_setup_rubyforge, :should_use_reek, :should_use_roodi,
+                  :should_use_rvm, :should_be_rusty, :should_use_pry,
                   :development_dependencies, :production_dependencies,
                   :options, :require_ruby_version, :should_create_bin,
-                  :git_remote, :use_readme_format, :should_use_pry,
-                  :should_be_rusty
+                  :git_remote, :use_readme_format
+                  
 
     def initialize(options = {})
       self.options = options
@@ -104,6 +105,7 @@ class Juwelier
       self.should_use_roodi       = options[:use_roodi]
       self.should_setup_rubyforge = options[:rubyforge]
       self.should_use_bundler     = options[:use_bundler]
+      self.should_use_rvm         = options[:use_rvm]
       self.should_use_semver      = options[:use_semver]
       self.require_ruby_version   = options[:use_required_version]
       self.should_create_bin      = options[:create_bin]
@@ -145,6 +147,7 @@ class Juwelier
 
     def run
       create_files
+      configure_project
       create_version_control
       $stdout.puts "Juwelier has prepared your gem in #{target_dir}"
       if should_create_remote_repo
@@ -173,7 +176,7 @@ class Juwelier
     end
 
     def lib_dir      ; 'lib'      ; end
-    def bin_dir      ; 'bin'      ; end    
+    def bin_dir      ; 'bin'      ; end
     def rust_dir     ; 'rust'     ; end
     def rust_src_dir ; rust_dir + '/src' ; end
 
@@ -208,13 +211,12 @@ class Juwelier
 
       output_template_in_target '.gitignore'
       output_template_in_target 'Rakefile'
-      if should_use_bundler
-        output_template_in_target 'Gemfile'
-        system 'bundle install'
-      end
+      output_template_in_target 'Gemfile' if should_use_bundler
       output_template_in_target 'LICENSE.txt'
       output_template_in_target "README.#{use_readme_format}"
       output_template_in_target '.document'
+      output_template_in_target '.ruby-version' unless should_use_rvm == false
+      output_template_in_target '.ruby-gemset' if should_use_rvm
 
       mkdir_in_target           lib_dir
       unless should_be_rusty
@@ -300,6 +302,35 @@ class Juwelier
       $stdout.puts "\tcreate\t#{destination}"
     end
 
+    def configure_project
+      FileUtils.cd target_dir do
+        execute_command "bundle install"   if should_use_bundler
+        execute_command "rspec --init"     if testing_framework == :rspec
+      end
+    end
+    
+    # RVM function taken from https://rvm.io/workflow/scripting#scripting
+    RVM_FUNCTION = <<~SHELL_SCRIPT
+      # Load RVM into a shell session *as a function*
+      if [[ -s "$HOME/.rvm/scripts/rvm" ]] ; then
+        # First try to load from a user install
+        source "$HOME/.rvm/scripts/rvm"
+      elif [[ -s "/usr/local/rvm/scripts/rvm" ]] ; then
+        # Then try to load from a root install
+        source "/usr/local/rvm/scripts/rvm"
+      fi
+    SHELL_SCRIPT
+    
+    def execute_command(command)
+      # check if not false because nil (default) should not count as false in this case
+      if should_use_rvm != false
+        rvm_command = "bash -c '#{RVM_FUNCTION}\ncd .\n#{command}'"
+        system rvm_command
+      else
+        system command
+      end
+    end
+    
     def create_version_control
       Dir.chdir(target_dir) do
         begin

--- a/lib/juwelier/generator.rb
+++ b/lib/juwelier/generator.rb
@@ -113,7 +113,7 @@ class Juwelier
 
       development_dependencies << ["cucumber", ">= 0"] if should_use_cucumber
 
-      development_dependencies << ["bundler", "~> 1.0"]
+      development_dependencies << ["bundler", ">= 1.0"]
       development_dependencies << ["juwelier", "~> #{Juwelier::Version::STRING}"]
       development_dependencies << ["simplecov", ">= 0"]
       
@@ -154,7 +154,7 @@ class Juwelier
     end
 
     def constant_name
-      self.project_name.underscore.camel
+      self.project_name.snake.camel
     end
 
     def extension_name
@@ -208,7 +208,10 @@ class Juwelier
 
       output_template_in_target '.gitignore'
       output_template_in_target 'Rakefile'
-      output_template_in_target 'Gemfile' if should_use_bundler
+      if should_use_bundler
+        output_template_in_target 'Gemfile'
+        system 'bundle install'
+      end
       output_template_in_target 'LICENSE.txt'
       output_template_in_target "README.#{use_readme_format}"
       output_template_in_target '.document'

--- a/lib/juwelier/generator/options.rb
+++ b/lib/juwelier/generator/options.rb
@@ -69,6 +69,10 @@ class Juwelier
             self[:use_bundler] = v
           end
 
+          o.on('--[no-]rvm', 'use RVM (Ruby enVironment Manager) for managing rubies/gemsets') do |v|
+            self[:use_rvm] = v
+          end
+
           o.on('--[no-]semver', 'use semver for managining gem version') do |v|
             self[:use_semver] = v
           end

--- a/lib/juwelier/generator/rspec_mixin.rb
+++ b/lib/juwelier/generator/rspec_mixin.rb
@@ -2,7 +2,7 @@ class Juwelier
   class Generator
     module RspecMixin
       def self.extended(generator)
-        generator.development_dependencies << ["rspec", "~> 3.5.0"]
+        generator.development_dependencies << ["rspec", ">= 3.5.0"]
       end
 
       def default_task

--- a/lib/juwelier/templates/.ruby-gemset
+++ b/lib/juwelier/templates/.ruby-gemset
@@ -1,0 +1,1 @@
+<%= project_name %>

--- a/lib/juwelier/templates/.ruby-version
+++ b/lib/juwelier/templates/.ruby-version
@@ -1,0 +1,2 @@
+<%= ENV['rvm_ruby_string'] %>
+

--- a/lib/juwelier/version.rb
+++ b/lib/juwelier/version.rb
@@ -1,8 +1,8 @@
 class Juwelier
   module Version
     MAJOR = 2
-    MINOR = 1
-    PATCH = 0
+    MINOR = 4
+    PATCH = 9
     BUILD = nil
 
     STRING = [MAJOR, MINOR, PATCH, BUILD].compact.join('.')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -117,7 +117,7 @@ class Test::Unit::TestCase
 
         if @command.respond_to? :repo
           @repo = Object.new
-          @command.repo = @repo 
+          @command.repo = @repo
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,7 +18,7 @@ end
 require 'rake'
 require 'shoulda'
 #require 'redgreen'
-require 'construct'
+require 'test_construct'
 require 'git'
 require 'time'
 
@@ -39,7 +39,7 @@ class RubyForgeStub
 end
 
 class Test::Unit::TestCase
-  include Construct::Helpers
+  include TestConstruct::Helpers
 
   def tmp_dir
     TMP_DIR


### PR DESCRIPTION
- Always generate RVM .ruby-version file defaulting to the same Ruby used to run juwelier command
- Support generating RVM files via the --rvm option, yielding .ruby-version and .ruby-gemset
- Avoid generating both .ruby-version and .ruby-gemset via the --no-rvm option
- Run `bundle install` after adding files to generated project when using --bundler
- Run `rspec --init` after adding files to generated project when using --rspec option (generating spec directory just like Jeweler did. This addresses my reported issue https://github.com/flajann2/juwelier/issues/13)
- Fix Juwelier's version in the version.rb file (will need another update when the next bump happens, please keep in mind)

(note: depends on https://github.com/flajann2/juwelier/pull/11 to pass the tests since it fixes the test suite, which was broken prior to my changes)

p.s. if you need maintainers, I’d be happy to help maintain Juwelier and Jeweler since I’ve been relying on since the mid 2000s and autoinstall for users of [Glimmer DSL for SWT](https://github.com/AndyObtiva/glimmer-dsl-swt) during scaffolding. 